### PR TITLE
modifying scipy import line to avoid deprecation warnings

### DIFF
--- a/src/diffcalc/util.py
+++ b/src/diffcalc/util.py
@@ -4,7 +4,7 @@ from typing import Any, Sequence, Tuple
 
 import numpy as np
 from numpy.linalg import norm
-from scipy.spatial.transform.rotation import Rotation
+from scipy.spatial import Rotation
 
 I: np.ndarray = np.identity(3)
 

--- a/src/diffcalc/util.py
+++ b/src/diffcalc/util.py
@@ -4,7 +4,7 @@ from typing import Any, Sequence, Tuple
 
 import numpy as np
 from numpy.linalg import norm
-from scipy.spatial import Rotation
+from scipy.spatial.transform import Rotation
 
 I: np.ndarray = np.identity(3)
 


### PR DESCRIPTION
specifically, modified src/util.py import from scipy.spatial.transform.rotation to scipy.spatial. 

This was producing warnings for python 3.8 and up in diffcalc_API repository, which uses this repository as a dependancy.
