### PR TITLE
modify structures to work in radians internally only

### DIFF
--- a/src/diffcalc/hkl/calc.py
+++ b/src/diffcalc/hkl/calc.py
@@ -75,8 +75,7 @@ class HklCalculation:
             Miller indices corresponding to the specified diffractometer
             position at the given wavelength.
         """
-        pos_in_rad = Position.asradians(pos)
-        [MU, DELTA, NU, ETA, CHI, PHI] = get_rotation_matrices(pos_in_rad)
+        [MU, DELTA, NU, ETA, CHI, PHI] = get_rotation_matrices(pos)
 
         q_lab = (NU @ DELTA - I) @ np.array([[0], [2 * pi / wavelength], [0]])  # 12
 
@@ -102,12 +101,11 @@ class HklCalculation:
             Returns alpha, beta, betain, betaout, naz, psi, qaz, tau, theta and
             ttheta angles.
         """
-        pos_in_rad = Position.asradians(pos)
         theta, qaz = self.__theta_and_qaz_from_detector_angles(
-            pos_in_rad.delta, pos_in_rad.nu
+            float(pos.delta), float(pos.nu)
         )  # (19)
 
-        [MU, DELTA, NU, ETA, CHI, PHI] = get_rotation_matrices(pos_in_rad)
+        [MU, DELTA, NU, ETA, CHI, PHI] = get_rotation_matrices(pos)
         Z = MU @ ETA @ CHI @ PHI
         D = NU @ DELTA
 
@@ -395,8 +393,7 @@ class HklCalculation:
             )
 
         tidy_solutions = [
-            self.__tidy_degenerate_solutions(Position(*pos, False))
-            for pos in solution_tuples
+            self.__tidy_degenerate_solutions(Position(*pos)) for pos in solution_tuples
         ]
 
         # def _find_duplicate_angles(el):
@@ -492,7 +489,6 @@ class HklCalculation:
                 desired_eta,
                 pos.chi,
                 pos.phi - eta_diff,
-                False,
             )
 
         elif (
@@ -519,7 +515,6 @@ class HklCalculation:
                 pos.eta,
                 pos.chi,
                 pos.phi + mu_diff,
-                False,
             )
         else:
             newpos = pos

--- a/tests/diffcalc/hkl/test_calc.py
+++ b/tests/diffcalc/hkl/test_calc.py
@@ -18,12 +18,12 @@
 
 import itertools
 from itertools import chain
-from math import cos, radians, sin, sqrt
+from math import cos, degrees, radians, sin, sqrt
 
 import pytest
 from diffcalc.hkl.calc import HklCalculation
 from diffcalc.hkl.constraints import Constraints
-from diffcalc.hkl.geometry import Position
+from diffcalc.hkl.geometry import Position, ureg
 from diffcalc.ub.calc import UBCalculation
 from diffcalc.util import DiffcalcException, I, y_rotation, z_rotation
 from numpy import array
@@ -121,8 +121,8 @@ class _BaseTest:
         pos = list(chain(*pos_virtual_angles_pairs_in_degrees))[::2]
         virtual = list(chain(*pos_virtual_angles_pairs_in_degrees))[1::2]
         assert_array_almost_equal_in_list(
-            pos_expected.astuple,
-            [p.astuple for p in pos],
+            tuple([degrees(float(item)) for item in pos_expected.astuple]),
+            [tuple([degrees(float(item)) for item in p.astuple]) for p in pos],
             self.places,
         )
         # assert_array_almost_equal(pos, pos_expected, self.places)
@@ -148,22 +148,30 @@ class _BaseTest:
         assert_second_dict_almost_in_first(virtual, virtual_expected)
 
     def case_generator(self, case):
-        self._check_angles_to_hkl(
+        new_case = Pair(
             case.name,
+            case.hkl,
+            Position(*case.position.astuple * ureg.deg),
             case.zrot,
             case.yrot,
-            case.hkl,
-            case.position,
             case.wavelength,
+        )
+        self._check_angles_to_hkl(
+            new_case.name,
+            new_case.zrot,
+            new_case.yrot,
+            new_case.hkl,
+            new_case.position,
+            new_case.wavelength,
             {},
         )
         self._check_hkl_to_angles(
-            case.name,
-            case.zrot,
-            case.yrot,
-            case.hkl,
-            case.position,
-            case.wavelength,
+            new_case.name,
+            new_case.zrot,
+            new_case.yrot,
+            new_case.hkl,
+            new_case.position,
+            new_case.wavelength,
             {},
         )
 
@@ -372,10 +380,10 @@ class TestCubicVertical(_TestCubic):
         hkl = (0.1, 0, 1.5)
         pos = Position(
             mu=0,
-            delta=97.46959231642,
+            delta=97.46959231642 * ureg.deg,
             nu=0,
-            eta=97.46959231642 / 2,
-            chi=86.18592516571,
+            eta=97.46959231642 / 2 * ureg.deg,
+            chi=86.18592516571 * ureg.deg,
             phi=0,
         )
         self._check_hkl_to_angles("", 0, 0, hkl, pos, wavelength)
@@ -2630,8 +2638,9 @@ class TestThreeTwoCircleForDiamondI06andI10(_BaseTest):
             chi=90,
             phi=-90,
         )
-        self._check_angles_to_hkl("001", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("001", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("001", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("001", 999, 999, hkl, new_pos, self.wavelength, {})
 
     def testHkl100(self):
         hkl = (1, 0, 0)
@@ -2643,8 +2652,9 @@ class TestThreeTwoCircleForDiamondI06andI10(_BaseTest):
             chi=0,
             phi=-90,
         )
-        self._check_angles_to_hkl("100", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("100", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("100", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("100", 999, 999, hkl, new_pos, self.wavelength, {})
 
     def testHkl101(self):
         hkl = (1, 0, 1)
@@ -2656,8 +2666,9 @@ class TestThreeTwoCircleForDiamondI06andI10(_BaseTest):
             chi=90,
             phi=-90,
         )
-        self._check_angles_to_hkl("101", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("101", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("101", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("101", 999, 999, hkl, new_pos, self.wavelength, {})
 
 
 class TestThreeTwoCircleForDiamondI06andI10Horizontal(_BaseTest):
@@ -2680,8 +2691,9 @@ class TestThreeTwoCircleForDiamondI06andI10Horizontal(_BaseTest):
             chi=0,
             phi=-90,
         )
-        self._check_angles_to_hkl("001", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("001", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("001", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("001", 999, 999, hkl, new_pos, self.wavelength, {})
 
     @pytest.mark.xfail(raises=DiffcalcException)  # q || chi
     def testHkl100(self):
@@ -2694,8 +2706,9 @@ class TestThreeTwoCircleForDiamondI06andI10Horizontal(_BaseTest):
             chi=0,
             phi=-90,
         )
-        self._check_angles_to_hkl("100", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("100", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("100", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("100", 999, 999, hkl, new_pos, self.wavelength, {})
 
     def testHkl101(self):
         hkl = (1, 0, 1)
@@ -2707,8 +2720,9 @@ class TestThreeTwoCircleForDiamondI06andI10Horizontal(_BaseTest):
             chi=0,
             phi=-90,
         )
-        self._check_angles_to_hkl("101", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("101", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("101", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("101", 999, 999, hkl, new_pos, self.wavelength, {})
 
 
 class TestThreeTwoCircleForDiamondI06andI10ChiDeltaEta(
@@ -2730,8 +2744,9 @@ class TestThreeTwoCircleForDiamondI06andI10ChiDeltaEta(
             chi=0,
             phi=-90,
         )
-        self._check_angles_to_hkl("001", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("001", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("001", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("001", 999, 999, hkl, new_pos, self.wavelength, {})
 
     def testHkl100(self):
         hkl = (1, 0, 0)
@@ -2743,8 +2758,9 @@ class TestThreeTwoCircleForDiamondI06andI10ChiDeltaEta(
             chi=0,
             phi=-90,
         )
-        self._check_angles_to_hkl("100", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("100", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("100", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("100", 999, 999, hkl, new_pos, self.wavelength, {})
 
 
 class TestFixedNazPsiEtaMode(_TestCubic):
@@ -2828,8 +2844,9 @@ class TestFixedNazPsiEtaMode(_TestCubic):
     )
     def testHKL(self, hkl, pos, places):
         self.places = places
-        self._check_angles_to_hkl("", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("", 999, 999, hkl, new_pos, self.wavelength, {})
 
 
 class TestFixedChiPhiAeqBMode_DiamondI07SurfaceNormalHorizontal(_TestCubic):
@@ -3013,8 +3030,9 @@ class TestFixedChiPhiAeqBMode_DiamondI07SurfaceNormalHorizontal(_TestCubic):
     )
     def testHKL(self, hkl, pos, places):
         self.places = places
-        self._check_angles_to_hkl("", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("", 999, 999, hkl, new_pos, self.wavelength, {})
 
 
 class TestFixedChiPhiAeqBModeSurfaceNormalVertical(_TestCubic):
@@ -3192,8 +3210,9 @@ class TestFixedChiPhiAeqBModeSurfaceNormalVertical(_TestCubic):
     )
     def testHKL(self, hkl, pos, places):
         self.places = places
-        self._check_angles_to_hkl("", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("", 999, 999, hkl, new_pos, self.wavelength, {})
 
 
 class TestFixedChiPhiPsiModeSurfaceNormalVerticalI16(_TestCubic):
@@ -3270,8 +3289,9 @@ class TestFixedChiPhiPsiModeSurfaceNormalVerticalI16(_TestCubic):
         ],
     )
     def testHKL(self, hkl, pos):
-        self._check_angles_to_hkl("", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("", 999, 999, hkl, new_pos, self.wavelength, {})
 
 
 class TestConstrain3Sample_ChiPhiEta(_TestCubic):
@@ -3288,11 +3308,12 @@ class TestConstrain3Sample_ChiPhiEta(_TestCubic):
         # self.mock_ubcalc.n_phi = np.array([[0.087867277], [0.906307787], [0.413383038]])
 
     def _check(self, hkl, pos, virtual_expected={}):
+        new_pos = Position(*pos.astuple * ureg.deg)
         self._check_angles_to_hkl(
-            "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+            "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
         )
         self._check_hkl_to_angles(
-            "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+            "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
         )
 
     def testHkl_all0_001(self):
@@ -3615,8 +3636,9 @@ class TestConstrain3Sample_MuChiPhi(_TestCubic):
     )
     def testHkl(self, hkl, pos, constraint):
         self.constraints.asdict = constraint
-        self._check_angles_to_hkl("", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("", 999, 999, hkl, new_pos, self.wavelength, {})
 
     # def testHkl_all0_001(self):
     #    self.constraints.asdict = {'chi': 90 * TORAD, 'phi': 0, 'mu': 0}
@@ -3759,8 +3781,9 @@ class TestConstrain3Sample_MuEtaChi(_TestCubic):
     )
     def testHKL(self, hkl, pos, constraint):
         self.constraints.asdict = constraint
-        self._check_angles_to_hkl("", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("", 999, 999, hkl, new_pos, self.wavelength, {})
 
     # def testHkl_all0_001(self):
     #    self.constraints.asdict = {'eta': radians(30), 'chi': 90 * TORAD, 'mu': 0}
@@ -3902,8 +3925,9 @@ class TestConstrain3Sample_MuEtaPhi(_TestCubic):
     )
     def testHKL(self, hkl, pos, constraint):
         self.constraints.asdict = constraint
-        self._check_angles_to_hkl("", 999, 999, hkl, pos, self.wavelength, {})
-        self._check_hkl_to_angles("", 999, 999, hkl, pos, self.wavelength, {})
+        new_pos = Position(*pos.astuple * ureg.deg)
+        self._check_angles_to_hkl("", 999, 999, hkl, new_pos, self.wavelength, {})
+        self._check_hkl_to_angles("", 999, 999, hkl, new_pos, self.wavelength, {})
 
     # def testHkl_all0_001(self):
     #    self.constraints.asdict = {'eta': 0, 'phi': 0, 'mu': radians(30)}
@@ -3972,12 +3996,13 @@ class TestHorizontalDeltaNadeta0_JiraI16_32_failure(_BaseTest):
         self.ubcalc.set_u(U)
 
     def _check(self, hkl, pos, virtual_expected={}, skip_test_pair_verification=False):
+        new_pos = Position(*pos.astuple * ureg.deg)
         if not skip_test_pair_verification:
             self._check_angles_to_hkl(
-                "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+                "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
             )
         self._check_hkl_to_angles(
-            "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+            "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
         )
 
     def test_hkl_bisecting_works_okay_on_i16(self):
@@ -4063,26 +4088,28 @@ class TestAnglesToHkl_I16Examples:
 
     def test_anglesToHkl_mu_0_gam_0(self):
         pos = PosFromI16sEuler(1, 1, 30, 0, 60, 0)
-        arrayeq_(self.hklcalc.get_hkl(pos, self.WL1), [1, 0, 0])
+        arrayeq_(
+            self.hklcalc.get_hkl(Position(*pos.astuple * ureg.deg), self.WL1), [1, 0, 0]
+        )
 
     def test_anglesToHkl_mu_0_gam_10(self):
         pos = PosFromI16sEuler(1, 1, 30, 0, 60, 10)
         arrayeq_(
-            self.hklcalc.get_hkl(pos, self.WL1),
+            self.hklcalc.get_hkl(Position(*pos.astuple * ureg.deg), self.WL1),
             [1.00379806, -0.006578435, 0.08682408],
         )
 
     def test_anglesToHkl_mu_10_gam_0(self):
         pos = PosFromI16sEuler(1, 1, 30, 10, 60, 0)
         arrayeq_(
-            self.hklcalc.get_hkl(pos, self.WL1),
+            self.hklcalc.get_hkl(Position(*pos.astuple * ureg.deg), self.WL1),
             [0.99620193, 0.0065784359, 0.08682408],
         )
 
     def test_anglesToHkl_arbitrary(self):
         pos = PosFromI16sEuler(1.9, 2.9, 30.9, 0.9, 60.9, 2.9)
         arrayeq_(
-            self.hklcalc.get_hkl(pos, self.WL1),
+            self.hklcalc.get_hkl(Position(*pos.astuple * ureg.deg), self.WL1),
             [1.01174189, 0.02368622, 0.06627361],
         )
 
@@ -4110,12 +4137,13 @@ class TestAnglesToHkl_I16Numerical(_BaseTest):
         virtual_expected={},
         skip_test_pair_verification=False,
     ):
+        new_pos = Position(*pos.astuple * ureg.deg)
         if not skip_test_pair_verification:
             self._check_angles_to_hkl(
-                testname, 999, 999, hkl, pos, self.wavelength, virtual_expected
+                testname, 999, 999, hkl, new_pos, self.wavelength, virtual_expected
             )
         self._check_hkl_to_angles(
-            testname, 999, 999, hkl, pos, self.wavelength, virtual_expected
+            testname, 999, 999, hkl, new_pos, self.wavelength, virtual_expected
         )
 
     def test_hkl_to_angles_given_UB(self):
@@ -4163,12 +4191,13 @@ class TestAnglesToHkl_I16GaAsExample(_BaseTest):
         self.ubcalc.set_u(U)
 
     def _check(self, hkl, pos, virtual_expected={}, skip_test_pair_verification=False):
+        new_pos = Position(*pos.astuple * ureg.deg)
         if not skip_test_pair_verification:
             self._check_angles_to_hkl(
-                "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+                "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
             )
         self._check_hkl_to_angles(
-            "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+            "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
         )
 
     def test_hkl_to_angles_given_UB(self):
@@ -4344,7 +4373,7 @@ class TestConstrainNazAlphaEta(_BaseTest):
         self.ubcalc.set_lattice(name="test", a=4.913, c=5.405)
         self.ubcalc.add_reflection(
             hkl=(0, 0, 1),
-            position=Position(7.31, 0, 10.62, 0, 0, 0),
+            position=Position(7.31 * ureg.deg, 0, 10.62 * ureg.deg, 0, 0, 0),
             energy=12.39842,
             tag="refl1",
         )
@@ -4354,12 +4383,13 @@ class TestConstrainNazAlphaEta(_BaseTest):
         self.ubcalc.n_hkl = (1.0, 0.0, 0.0)
 
     def _check(self, hkl, pos, virtual_expected={}, skip_test_pair_verification=False):
+        new_pos = Position(*pos.astuple * ureg.deg)
         if not skip_test_pair_verification:
             self._check_angles_to_hkl(
-                "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+                "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
             )
         self._check_hkl_to_angles(
-            "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+            "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
         )
 
     def test_hkl_to_angles_given_UB(self):

--- a/tests/diffcalc/hkl/test_calc_methods.py
+++ b/tests/diffcalc/hkl/test_calc_methods.py
@@ -21,7 +21,7 @@ from unittest.mock import Mock
 
 from diffcalc.hkl.calc import HklCalculation
 from diffcalc.hkl.constraints import Constraints
-from diffcalc.hkl.geometry import Position
+from diffcalc.hkl.geometry import Position, ureg
 from diffcalc.ub.calc import UBCalculation
 from diffcalc.util import I
 from numpy import array
@@ -48,24 +48,22 @@ class TestPosition:
             == "Position(mu: 1.1234, delta: 2.3456, nu: 3.4567, eta: 4.5678, chi: 5.6789, phi: 6.7891)"
         )
 
-        pos4 = Position(
-            pi / 1.0, pi / 2.0, pi / 3.0, pi / 4.0, pi / 5.0, pi / 6.0, indegrees=False
-        )
+        pos4 = Position(pi / 1.0, pi / 2.0, pi / 3.0, pi / 4.0, pi / 5.0, pi / 6.0)
         assert (
             str(pos4)
-            == f"Position(mu: {degrees(pi / 1.0):.4f}, delta: {degrees(pi / 2.0):.4f}, nu: {degrees(pi / 3.0):.4f}, eta: {degrees(pi / 4.0):.4f}, chi: {degrees(pi / 5.0):.4f}, phi: {degrees(pi / 6.0):.4f})"
+            == f"Position(mu: {(pi / 1.0):.4f}, delta: {(pi / 2.0):.4f}, nu: {(pi / 3.0):.4f}, eta: {(pi / 4.0):.4f}, chi: {(pi / 5.0):.4f}, phi: {(pi / 6.0):.4f})"
         )
 
     def test_getter_setter(self):
         pos_deg = Position()
-        pos_rad = Position(indegrees=False)
+        pos_rad = Position()
         for i, field in enumerate(pos_deg.fields, 1):
-            setattr(pos_deg, field, float(i))
+            setattr(pos_deg, field, float(i) * ureg.deg)
             setattr(pos_rad, field, pi / float(i))
 
         for i, field in enumerate(pos_deg.fields, 1):
-            assert_almost_equal(getattr(pos_deg, field), float(i))
-            assert_almost_equal(getattr(pos_rad, field), pi / float(i))
+            assert_almost_equal(degrees(float(getattr(pos_deg, field))), i)
+            assert_almost_equal(float(getattr(pos_rad, field)), pi / i)
 
 
 class Test_position_to_virtual_angles:
@@ -82,7 +80,14 @@ class Test_position_to_virtual_angles:
         self, name, expected, mu=-99, delta=99, nu=99, eta=99, chi=99, phi=99
     ):
         """All in degrees"""
-        pos = Position(mu=mu, delta=delta, nu=nu, eta=eta, chi=chi, phi=phi)
+        pos = Position(
+            mu * ureg.deg,
+            delta * ureg.deg,
+            nu * ureg.deg,
+            eta * ureg.deg,
+            chi * ureg.deg,
+            phi * ureg.deg,
+        )
         calculated = self.calc.get_virtual_angles(pos, False)[name]
         if isnan(expected):
             assert isnan(calculated)

--- a/tests/diffcalc/hkl/test_calc_surface.py
+++ b/tests/diffcalc/hkl/test_calc_surface.py
@@ -21,7 +21,7 @@
 from collections import namedtuple
 
 import pytest
-from diffcalc.hkl.geometry import Position
+from diffcalc.hkl.geometry import Position, ureg
 from diffcalc.ub.calc import UBCalculation
 from diffcalc.ub.crystal import Crystal
 from diffcalc.util import DiffcalcException, I
@@ -44,12 +44,13 @@ class TestSurfaceNormalVerticalCubic(_BaseTest):
         self.ubcalc.set_u(I)
 
     def _check(self, hkl, pos, virtual_expected={}):
+        new_pos = Position(*pos.astuple * ureg.deg) if pos is not None else None
         if pos is not None:
             self._check_angles_to_hkl(
-                "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+                "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
             )
         self._check_hkl_to_angles(
-            "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+            "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
         )
 
     def testHkl001(self):
@@ -161,13 +162,13 @@ class TestUBCalculationWithWillmotStrategy_Si_5_5_12_FixedMuEta:
         self.ubcalc.set_lattice("Si_5_5_12", 7.68, 53.48, 75.63, 90, 90, 90)
         self.ubcalc.add_reflection(
             HKL0,
-            willmott_to_you_fixed_mu_eta(REF0),
+            Position(*willmott_to_you_fixed_mu_eta(REF0).astuple * ureg.deg),
             ENERGY,
             "ref0",
         )
         self.ubcalc.add_reflection(
             HKL1,
-            willmott_to_you_fixed_mu_eta(REF1),
+            Position(*willmott_to_you_fixed_mu_eta(REF1).astuple * ureg.deg),
             ENERGY,
             "ref1",
         )
@@ -194,11 +195,12 @@ class TestFixedMuEta(_BaseTest):
         self.ubcalc.set_u(U_DIFFCALC)
 
     def _check(self, hkl, pos, virtual_expected={}):
+        new_pos = Position(*pos.astuple * ureg.deg)
         self._check_angles_to_hkl(
-            "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+            "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
         )
         self._check_hkl_to_angles(
-            "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+            "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
         )
 
     def testHkl_2_19_32_found_orientation_setting(self):
@@ -209,7 +211,7 @@ class TestFixedMuEta(_BaseTest):
             999,
             999,
             HKL0,
-            self._convert_willmott_pos(REF0),
+            Position(*self._convert_willmott_pos(REF0).astuple * ureg.deg),
             self.wavelength,
             {"alpha": 2},
         )
@@ -222,7 +224,7 @@ class TestFixedMuEta(_BaseTest):
             999,
             999,
             HKL1,
-            self._convert_willmott_pos(REF1),
+            Position(*self._convert_willmott_pos(REF1).astuple * ureg.deg),
             self.wavelength,
             {"alpha": 2},
         )
@@ -283,13 +285,13 @@ class TestUBCalculationWithWillmotStrategy_Si_5_5_12_FixedMuChi:
         self.ubcalc.set_lattice("Si_5_5_12", 7.68, 53.48, 75.63, 90, 90, 90)
         self.ubcalc.add_reflection(
             HKL0,
-            willmott_to_you_fixed_mu_chi(REF0),
+            Position(*willmott_to_you_fixed_mu_chi(REF0).astuple * ureg.deg),
             ENERGY,
             "ref0",
         )
         self.ubcalc.add_reflection(
             HKL1,
-            willmott_to_you_fixed_mu_chi(REF1),
+            Position(*willmott_to_you_fixed_mu_chi(REF1).astuple * ureg.deg),
             ENERGY,
             "ref1",
         )
@@ -394,13 +396,13 @@ class TestUBCalculation_Pt531_FixedMuChi:
 
         self.ubcalc.add_reflection(
             Pt531_HKL0,
-            willmott_to_you_fixed_mu_chi(Pt531_REF0),
+            Position(*willmott_to_you_fixed_mu_chi(Pt531_REF0).astuple * ureg.deg),
             12.39842 / Pt531_WAVELENGTH,
             "ref0",
         )
         self.ubcalc.add_reflection(
             Pt531_HKL1,
-            willmott_to_you_fixed_mu_chi(Pt531_REF1),
+            Position(*willmott_to_you_fixed_mu_chi(Pt531_REF1).astuple * ureg.deg),
             12.39842 / Pt531_WAVELENGTH,
             "ref1",
         )
@@ -430,16 +432,17 @@ class Test_Pt531_FixedMuChi(_BaseTest):
         self.ubcalc.set_u(Pt531_U_DIFFCALC)
 
     def _check(self, hkl, pos, virtual_expected={}, fails=False):
+        new_pos = Position(*pos.astuple * ureg.deg)
         self._check_angles_to_hkl(
-            "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+            "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
         )
         if fails:
             self._check_hkl_to_angles_fails(
-                "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+                "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
             )
         else:
             self._check_hkl_to_angles(
-                "", 999, 999, hkl, pos, self.wavelength, virtual_expected
+                "", 999, 999, hkl, new_pos, self.wavelength, virtual_expected
             )
 
     def testHkl_0_found_orientation_setting(self):
@@ -450,7 +453,7 @@ class Test_Pt531_FixedMuChi(_BaseTest):
             999,
             999,
             Pt531_HKL0,
-            self._convert_willmott_pos(Pt531_REF0),
+            Position(*self._convert_willmott_pos(Pt531_REF0).astuple * ureg.deg),
             self.wavelength,
             {"alpha": 2},
         )
@@ -463,7 +466,7 @@ class Test_Pt531_FixedMuChi(_BaseTest):
             999,
             999,
             Pt531_HKL1,
-            self._convert_willmott_pos(Pt531_REF1),
+            Position(*self._convert_willmott_pos(Pt531_REF1).astuple * ureg.deg),
             self.wavelength,
             {"alpha": 2},
         )

--- a/tests/diffcalc/ub/test_calculation.py
+++ b/tests/diffcalc/ub/test_calculation.py
@@ -20,6 +20,7 @@ import pickle
 from math import pi
 
 import pytest
+from diffcalc.hkl.geometry import Position, ureg
 from diffcalc.ub.calc import UBCalculation
 from diffcalc.util import DiffcalcException
 from numpy import array, save
@@ -44,8 +45,8 @@ REF1b = PosFromI16sEuler(1, 91, 30, 0, 60, 0)
 def testAgainstI16Results():
     ubcalc = UBCalculation("cubcalc")
     ubcalc.set_lattice("latt", 1, 1, 1, 90, 90, 90)
-    ubcalc.add_reflection((1, 0, 0), REF1a, EN1, "100")
-    ubcalc.add_reflection((0, 0, 1), REF1b, EN1, "001")
+    ubcalc.add_reflection((1, 0, 0), Position(*REF1a.astuple * ureg.deg), EN1, "100")
+    ubcalc.add_reflection((0, 0, 1), Position(*REF1b.astuple * ureg.deg), EN1, "001")
     ubcalc.calc_ub()
     matrixeq_(ubcalc.UB, UB1)
 
@@ -78,9 +79,11 @@ def test_save_and_restore_ubcalc_with_lattice(tmpdir):
 def test_save_and_restore_ubcalc_with_reflections(tmpdir):
     NAME = "test_save_and_restore_ubcalc_with_reflections"
     ubcalc = UBCalculation(NAME)
-    ubcalc.add_reflection((1, 0, 0), REF1a, EN1, "100")
-    ubcalc.add_reflection((0, 0, 1), REF1b, EN1, "001")
-    ubcalc.add_reflection((0, 0, 1.5), REF1b, EN1, "001_5")
+    ubcalc.add_reflection((1, 0, 0), Position(*REF1a.astuple * ureg.deg), EN1, "100")
+    ubcalc.add_reflection((0, 0, 1), Position(*REF1b.astuple * ureg.deg), EN1, "001")
+    ubcalc.add_reflection(
+        (0, 0, 1.5), Position(*REF1b.astuple * ureg.deg), EN1, "001_5"
+    )
     ref1 = ubcalc.get_reflection(1)
     ref2 = ubcalc.get_reflection(2)
     ref3 = ubcalc.get_reflection(3)
@@ -99,8 +102,8 @@ def test_save_and_restore_ubcalc_with_UB_from_two_ref(tmpdir):
     NAME = "test_save_and_restore_ubcalc_with_UB_from_two_ref"
     ubcalc = UBCalculation(NAME)
     ubcalc.set_lattice("latt", 1, 1, 1, 90, 90, 90)
-    ubcalc.add_reflection((1, 0, 0), REF1a, EN1, "100")
-    ubcalc.add_reflection((0, 0, 1), REF1b, EN1, "001")
+    ubcalc.add_reflection((1, 0, 0), Position(*REF1a.astuple * ureg.deg), EN1, "100")
+    ubcalc.add_reflection((0, 0, 1), Position(*REF1b.astuple * ureg.deg), EN1, "001")
     ubcalc.calc_ub()
     matrixeq_(ubcalc.UB, UB1)
 
@@ -115,7 +118,7 @@ def test_save_and_restore_ubcalc_with_UB_from_one_ref(tmpdir):
     NAME = "test_save_and_restore_ubcalc_with_UB_from_one_ref"
     ubcalc = UBCalculation(NAME)
     ubcalc.set_lattice("latt", 1, 1, 1, 90, 90, 90)
-    ubcalc.add_reflection((1, 0, 0), REF1a, EN1, "100")
+    ubcalc.add_reflection((1, 0, 0), Position(*REF1a.astuple * ureg.deg), EN1, "100")
     ubcalc.calc_ub()
     matrixeq_(ubcalc.UB, UB1, places=2)
 

--- a/tests/diffcalc/ub/test_calculation_you.py
+++ b/tests/diffcalc/ub/test_calculation_you.py
@@ -18,7 +18,7 @@
 
 from math import pi
 
-from diffcalc.hkl.geometry import Position
+from diffcalc.hkl.geometry import Position, ureg
 from diffcalc.ub.calc import UBCalculation
 from numpy import array
 
@@ -56,8 +56,8 @@ REF1b = PosFromI16sEuler(1, 91, 30, 0, 60, 0)
 def testAgainstI16Results():
     ubcalc = UBCalculation("cubcalc")
     ubcalc.set_lattice("latt", 1, 1, 1, 90, 90, 90)
-    ubcalc.add_reflection((1, 0, 0), REF1a, EN1, "100")
-    ubcalc.add_reflection((0, 0, 1), REF1b, EN1, "001")
+    ubcalc.add_reflection((1, 0, 0), Position(*REF1a.astuple * ureg.deg), EN1, "100")
+    ubcalc.add_reflection((0, 0, 1), Position(*REF1b.astuple * ureg.deg), EN1, "001")
     ubcalc.calc_ub()
     matrixeq_(ubcalc.UB, UB1)
 

--- a/tests/diffcalc/ub/test_ub.py
+++ b/tests/diffcalc/ub/test_ub.py
@@ -21,7 +21,7 @@ from math import degrees, radians, sqrt
 import pytest
 from diffcalc.hkl.calc import HklCalculation
 from diffcalc.hkl.constraints import Constraints
-from diffcalc.hkl.geometry import Position
+from diffcalc.hkl.geometry import Position, ureg
 from diffcalc.ub.calc import ReferenceVector, UBCalculation
 from diffcalc.util import DiffcalcException
 from numpy import array
@@ -456,9 +456,13 @@ CRYSTAL ORIENTATIONS
             ubcalc = UBCalculation("test_calcub")
             ubcalc.set_lattice(s.name, *s.lattice)
             r = s.ref1
-            ubcalc.add_reflection((r.h, r.k, r.l), r.pos, r.energy, r.tag)
+            ubcalc.add_reflection(
+                (r.h, r.k, r.l), Position(*r.pos.astuple * ureg.deg), r.energy, r.tag
+            )
             r = s.ref2
-            ubcalc.add_reflection((r.h, r.k, r.l), r.pos, r.energy, r.tag)
+            ubcalc.add_reflection(
+                (r.h, r.k, r.l), Position(*r.pos.astuple * ureg.deg), r.energy, r.tag
+            )
             ubcalc.calc_ub(s.ref1.tag, s.ref2.tag)
             mneq_(
                 ubcalc.UB,
@@ -497,7 +501,9 @@ CRYSTAL ORIENTATIONS
             4,
             note="wrong UB matrix after calculating U",
         )
-        ubcalc.add_reflection((r1.h, r1.k, r1.l), r1.pos, r1.energy, r1.tag)
+        ubcalc.add_reflection(
+            (r1.h, r1.k, r1.l), Position(*r1.pos.astuple * ureg.deg), r1.energy, r1.tag
+        )
         ubcalc.calc_ub(r1.tag, tag2)
         mneq_(
             ubcalc.UB,
@@ -505,7 +511,9 @@ CRYSTAL ORIENTATIONS
             4,
             note="wrong UB matrix after calculating U",
         )
-        ubcalc.add_reflection((r2.h, r2.k, r2.l), r2.pos, r2.energy, r2.tag)
+        ubcalc.add_reflection(
+            (r2.h, r2.k, r2.l), Position(*r2.pos.astuple * ureg.deg), r2.energy, r2.tag
+        )
         ubcalc.calc_ub(tag1, r2.tag)
         mneq_(
             ubcalc.UB,
@@ -520,7 +528,7 @@ CRYSTAL ORIENTATIONS
         ubcalc.set_miscut(None, 0)
         ubcalc.refine_ub(
             (1, 1, 0),
-            Position(mu=0, delta=60, nu=0, eta=30, chi=0, phi=0),
+            Position(0, 60 * ureg.deg, 0, 30 * ureg.deg, 0, 0),
             1.0,
             True,
             True,
@@ -538,7 +546,12 @@ CRYSTAL ORIENTATIONS
             ubcalc = UBCalculation("test_fit_ub_matrix")
             a, b, c, alpha, beta, gamma = s.lattice
             for r in s.reflist:
-                ubcalc.add_reflection((r.h, r.k, r.l), r.pos, r.energy, r.tag)
+                ubcalc.add_reflection(
+                    (r.h, r.k, r.l),
+                    Position(*r.pos.astuple * ureg.deg),
+                    r.energy,
+                    r.tag,
+                )
             ubcalc.set_lattice(s.name, s.system, *s.lattice)
             ubcalc.calc_ub(s.ref1.tag, s.ref2.tag)
 


### PR DESCRIPTION
Any users wanting to use degrees can use Pint quantities. 

For example, the position object works entirely in radians now. But a user can specify,

```
from pint import UnitRegistry

ureg = UnitRegistry()
pos = Position(0, 30 * ureg.deg, 60 * ureg.deg, 0, 0, 90 * ureg.deg)
```

and this position can be passed around all internal diffcalc functions with no change in output. If they instead wrote,

`pos = Position(0, 30, 60, 0, 0, 90)`

This would be interpreted in radians by default.
