### PR TITLE
Use degrees as a default angle unit

### DIFF
--- a/src/diffcalc/hkl/calc_func.py
+++ b/src/diffcalc/hkl/calc_func.py
@@ -1,6 +1,6 @@
 """Module implementing intermediate calculations used in HKLCalculation class."""
 import logging
-from math import acos, asin, atan2, cos, degrees, sin, sqrt
+from math import acos, asin, atan2, cos, degrees, hypot, sin
 from typing import Dict, Iterator, List, Optional, Tuple
 
 import numpy as np
@@ -232,7 +232,7 @@ def __get_last_sample_angle(
             "Please choose a different set of constraints."
         )
     ks = atan2(A, B)
-    acos_alp = acos(bound(C / sqrt(A**2 + B**2)))
+    acos_alp = acos(bound(C / hypot(A, B)))
     if is_small(acos_alp):
         alp_list = [
             ks,

--- a/src/diffcalc/hkl/calc_sample.py
+++ b/src/diffcalc/hkl/calc_sample.py
@@ -1,7 +1,20 @@
 """Module implementing intermediate calculations in constrained sample geometry."""
 import logging
 from itertools import product
-from math import acos, asin, atan, atan2, cos, degrees, isnan, pi, sin, sqrt, tan
+from math import (
+    acos,
+    asin,
+    atan,
+    atan2,
+    cos,
+    degrees,
+    isnan,
+    pi,
+    radians,
+    sin,
+    sqrt,
+    tan,
+)
 from typing import Dict, Iterator, Optional, Tuple
 
 import numpy as np
@@ -24,7 +37,7 @@ def _calc_N(Q: np.ndarray, n: np.ndarray) -> np.ndarray:
     """Return N as described by Equation 31."""
     Q = normalised(Q)
     n = normalised(n)
-    if is_small(angle_between_vectors(Q, n)):
+    if is_small(radians(angle_between_vectors(Q, n))):
         # Replace the reference vector with an alternative vector from Eq.(78)
         def __key_func(v):
             return v[1]  # Workaround for mypy issue #9590

--- a/src/diffcalc/hkl/calc_sample.py
+++ b/src/diffcalc/hkl/calc_sample.py
@@ -8,6 +8,7 @@ from math import (
     atan2,
     cos,
     degrees,
+    hypot,
     isnan,
     pi,
     radians,
@@ -47,7 +48,7 @@ def _calc_N(Q: np.ndarray, n: np.ndarray) -> np.ndarray:
             key=__key_func,
         )
         idx_1, idx_2 = (idx for idx in range(3) if idx != idx_min)
-        qval = sqrt(Q[idx_1, 0] * Q[idx_1, 0] + Q[idx_2, 0] * Q[idx_2, 0])
+        qval = hypot(Q[idx_1, 0], Q[idx_2, 0])
         n[idx_min, 0] = qval
         n[idx_1, 0] = -Q[idx_min, 0] * Q[idx_1, 0] / qval
         n[idx_2, 0] = -Q[idx_min, 0] * Q[idx_2, 0] / qval
@@ -266,7 +267,7 @@ def __calc_sample_con_mu_eta(
                 "vector or phi constraints have been set.\nPlease choose a different "
                 "set of constraints."
             )
-        bot = bound(-V[1, 0] / sqrt(N_phi[0, 0] ** 2 + N_phi[1, 0] ** 2))
+        bot = bound(-V[1, 0] / hypot(N_phi[0, 0], N_phi[1, 0]))
         eps = atan2(N_phi[1, 0], N_phi[0, 0])
         phi_vals = [asin(bot) + eps, pi - asin(bot) + eps]  # (59)
     except AssertionError:
@@ -424,7 +425,7 @@ def __calc_sample_con_mu_phi(
     E = rot_PHI(phi) @ N_phi
 
     try:
-        bot = bound(-V[2, 0] / sqrt(E[0, 0] ** 2 + E[2, 0] ** 2))
+        bot = bound(-V[2, 0] / hypot(E[0, 0], E[2, 0]))
     except AssertionError:
         return
     eps = atan2(E[2, 0], E[0, 0])
@@ -459,7 +460,7 @@ def __calc_sample_con_mu_chi(
         ks = atan2(A, B)
     try:
         acos_phi = acos(
-            bound((N_phi[2, 0] * cos(chi) - V20) / (sin(chi) * sqrt(A**2 + B**2)))
+            bound((N_phi[2, 0] * cos(chi) - V20) / (sin(chi) * hypot(A, B)))
         )
     except AssertionError:
         return
@@ -510,9 +511,7 @@ def __calc_sample_con_eta_phi(
     sgn = sign(cos(eta))
     eps = atan2(X * sgn, Y * sgn)
     try:
-        acos_rhs = acos(
-            bound((sin(qaz) * cos(theta) / cos(eta) - V) / sqrt(X**2 + Y**2))
-        )
+        acos_rhs = acos(bound((sin(qaz) * cos(theta) / cos(eta) - V) / hypot(X, Y)))
     except AssertionError:
         return
     if is_small(acos_rhs):
@@ -556,7 +555,7 @@ def __calc_sample_con_eta_chi(
         acos_V00 = acos(
             bound(
                 (cos(theta) * sin(qaz) - N_phi[2, 0] * cos(eta) * sin(chi))
-                / sqrt(A**2 + B**2)
+                / hypot(A, B)
             )
         )
     except AssertionError:

--- a/src/diffcalc/hkl/constraints.py
+++ b/src/diffcalc/hkl/constraints.py
@@ -61,7 +61,6 @@ class Constraints:
     def __init__(
         self,
         constraints: Collection[Union[Tuple[str, float], str]] = None,
-        indegrees: bool = True,
     ):
         """Object for setting diffractometer angle constraints."""
         self._delta = _Constraint("delta", _con_category.DETECTOR, _con_type.VALUE)
@@ -105,7 +104,6 @@ class Constraints:
             self._bisect,
             self._omega,
         )
-        self.indegrees = indegrees
         if constraints is not None:
             if isinstance(constraints, dict):
                 self.asdict = constraints
@@ -250,7 +248,7 @@ class Constraints:
             if isinstance(con.value, bool):
                 return con.value
             elif isinstance(con.value, (int, float)):
-                return degrees(con.value) if self.indegrees else con.value
+                return degrees(con.value)
             else:
                 raise DiffcalcException(
                     f"Invalid {con.name} value type: {type(con.value)}"
@@ -273,7 +271,7 @@ class Constraints:
                     )
             if con._type is _con_type.VALUE:
                 try:
-                    con.value = radians(float(val)) if self.indegrees else float(val)
+                    con.value = radians(float(val))
                     return
                 except ValueError:
                     raise DiffcalcException(
@@ -605,42 +603,6 @@ class Constraints:
             lines.append("!   %d more constraints required" % required)
         lines.extend([self._report_constraint(con) for con in self._all if con.active])
         return lines
-
-    @classmethod
-    def asdegrees(cls, constraints: "Constraints") -> "Constraints":
-        """Create new Constraints object with angles in degrees.
-
-        Parameters
-        ----------
-        constraints: Constraints
-            Input Constraints object
-
-        Returns
-        -------
-        Constraints
-            New Constraints object with angles in degrees.
-        """
-        res = cls(constraints.asdict, indegrees=constraints.indegrees)
-        res.indegrees = True
-        return res
-
-    @classmethod
-    def asradians(cls, constraints: "Constraints") -> "Constraints":
-        """Create new Constraints object with angles in radians.
-
-        Parameters
-        ----------
-        constraints: Constraints
-            Input Position object
-
-        Returns
-        -------
-        Constraints
-            New Constraints object with angles in radians.
-        """
-        res = cls(constraints.asdict, indegrees=constraints.indegrees)
-        res.indegrees = False
-        return res
 
     def is_fully_constrained(self, con: Optional[_Constraint] = None) -> bool:
         """Check if configuration is fully constrained.

--- a/src/diffcalc/hkl/geometry.py
+++ b/src/diffcalc/hkl/geometry.py
@@ -38,8 +38,6 @@ class Position:
         chi angle value
     phi: float, default = 0.0
         phi angle value
-    indegrees: bool, default = True
-        If True, arguments are angles in degrees.
     """
 
     fields: Tuple[str, str, str, str, str, str] = (
@@ -59,15 +57,13 @@ class Position:
         eta: float = 0.0,
         chi: float = 0.0,
         phi: float = 0.0,
-        indegrees: bool = True,
     ):
-        self._mu: float = radians(mu) if indegrees else mu
-        self._delta: float = radians(delta) if indegrees else delta
-        self._nu: float = radians(nu) if indegrees else nu
-        self._eta: float = radians(eta) if indegrees else eta
-        self._chi: float = radians(chi) if indegrees else chi
-        self._phi: float = radians(phi) if indegrees else phi
-        self.indegrees: bool = indegrees
+        self._mu: float = radians(mu)
+        self._delta: float = radians(delta)
+        self._nu: float = radians(nu)
+        self._eta: float = radians(eta)
+        self._chi: float = radians(chi)
+        self._phi: float = radians(phi)
 
     def __str__(self):
         """Represent Position object information as a string.
@@ -77,9 +73,9 @@ class Position:
         str
             Position object string representation.
         """
-        if self.indegrees:
-            return f"Position({', '.join((f'{k}: {v:.4f}' for k, v in self.asdict.items()))})"
-        return f"Position({', '.join((f'{k}: {degrees(v):.4f}' for k, v in self.asdict.items()))})"
+        return (
+            f"Position({', '.join((f'{k}: {v:.4f}' for k, v in self.asdict.items()))})"
+        )
 
     def __eq__(self, other):
         """Check if two Position objects are equivalent.
@@ -99,56 +95,14 @@ class Position:
 
         return False
 
-    @classmethod
-    def asdegrees(cls, pos: "Position") -> "Position":
-        """Create new Position object with angles in degrees.
-
-        Parameters
-        ----------
-        pos: Position
-            Input Position object
-
-        Returns
-        -------
-        Position
-            New Position object with angles in degrees.
-        """
-        res = cls(**pos.asdict, indegrees=pos.indegrees)
-        res.indegrees = True
-        return res
-
-    @classmethod
-    def asradians(cls, pos: "Position") -> "Position":
-        """Create new Position object with angles in radians.
-
-        Parameters
-        ----------
-        pos: Position
-            Input Position object
-
-        Returns
-        -------
-        Position
-            New Position object with angles in radians.
-        """
-        res = cls(**pos.asdict, indegrees=pos.indegrees)
-        res.indegrees = False
-        return res
-
     @property
     def mu(self) -> Union[float, None]:
         """Value of of mu angle."""
-        if self.indegrees:
-            return degrees(self._mu)
-        else:
-            return self._mu
+        return degrees(self._mu)
 
     @mu.setter
     def mu(self, val):
-        if self.indegrees:
-            self._mu = radians(val)
-        else:
-            self._mu = val
+        self._mu = radians(val)
 
     @mu.deleter
     def mu(self):
@@ -157,17 +111,11 @@ class Position:
     @property
     def delta(self) -> Union[float, None]:
         """Value of of delta angle."""
-        if self.indegrees:
-            return degrees(self._delta)
-        else:
-            return self._delta
+        return degrees(self._delta)
 
     @delta.setter
     def delta(self, val):
-        if self.indegrees:
-            self._delta = radians(val)
-        else:
-            self._delta = val
+        self._delta = radians(val)
 
     @delta.deleter
     def delta(self):
@@ -176,17 +124,11 @@ class Position:
     @property
     def nu(self) -> Union[float, None]:
         """Value of of nu angle."""
-        if self.indegrees:
-            return degrees(self._nu)
-        else:
-            return self._nu
+        return degrees(self._nu)
 
     @nu.setter
     def nu(self, val):
-        if self.indegrees:
-            self._nu = radians(val)
-        else:
-            self._nu = val
+        self._nu = radians(val)
 
     @nu.deleter
     def nu(self):
@@ -195,17 +137,11 @@ class Position:
     @property
     def eta(self) -> Union[float, None]:
         """Value of of eta angle."""
-        if self.indegrees:
-            return degrees(self._eta)
-        else:
-            return self._eta
+        return degrees(self._eta)
 
     @eta.setter
     def eta(self, val):
-        if self.indegrees:
-            self._eta = radians(val)
-        else:
-            self._eta = val
+        self._eta = radians(val)
 
     @eta.deleter
     def eta(self):
@@ -214,17 +150,11 @@ class Position:
     @property
     def chi(self) -> Union[float, None]:
         """Value of of chi angle."""
-        if self.indegrees:
-            return degrees(self._chi)
-        else:
-            return self._chi
+        return degrees(self._chi)
 
     @chi.setter
     def chi(self, val):
-        if self.indegrees:
-            self._chi = radians(val)
-        else:
-            self._chi = val
+        self._chi = radians(val)
 
     @chi.deleter
     def chi(self):
@@ -233,17 +163,11 @@ class Position:
     @property
     def phi(self) -> Union[float, None]:
         """Value of of phi angle."""
-        if self.indegrees:
-            return degrees(self._phi)
-        else:
-            return self._phi
+        return degrees(self._phi)
 
     @phi.setter
     def phi(self, val):
-        if self.indegrees:
-            self._phi = radians(val)
-        else:
-            self._phi = val
+        self._phi = radians(val)
 
     @phi.deleter
     def phi(self):
@@ -293,8 +217,7 @@ def get_rotation_matrices(
         Tuple containing set of rotation matrices corresponding to
         input diffractometer angle values.
     """
-    pos_in_rad = Position.asradians(pos)
-    mu, delta, nu, eta, chi, phi = pos_in_rad.astuple
+    mu, delta, nu, eta, chi, phi = (radians(val) for val in pos.astuple)
     return (
         rot_MU(mu),
         rot_DELTA(delta),
@@ -416,8 +339,7 @@ def get_q_phi(pos: Position) -> np.ndarray:
     matrix:
         Scattering vector coordinates corresponding to the input position.
     """
-    pos_in_rad = Position.asradians(pos)
-    [MU, DELTA, NU, ETA, CHI, PHI] = get_rotation_matrices(pos_in_rad)
+    [MU, DELTA, NU, ETA, CHI, PHI] = get_rotation_matrices(pos)
     # Equation 12: Compute the momentum transfer vector in the lab  frame
     y = np.array([[0], [1], [0]])
     q_lab = (NU @ DELTA - I) @ y

--- a/src/diffcalc/hkl/geometry.py
+++ b/src/diffcalc/hkl/geometry.py
@@ -9,7 +9,7 @@ References
        J. Appl. Cryst. (1999). 32, 614-623.
 """
 from math import degrees, radians
-from typing import Dict, Tuple, Union
+from typing import Dict, Tuple
 
 import numpy as np
 from diffcalc.util import I, x_rotation, y_rotation, z_rotation
@@ -96,82 +96,82 @@ class Position:
         return False
 
     @property
-    def mu(self) -> Union[float, None]:
+    def mu(self) -> float:
         """Value of of mu angle."""
         return degrees(self._mu)
 
     @mu.setter
-    def mu(self, val):
+    def mu(self, val: float) -> None:
         self._mu = radians(val)
 
     @mu.deleter
-    def mu(self):
-        self._mu = None
+    def mu(self) -> None:
+        self._mu = float("nan")
 
     @property
-    def delta(self) -> Union[float, None]:
+    def delta(self) -> float:
         """Value of of delta angle."""
         return degrees(self._delta)
 
     @delta.setter
-    def delta(self, val):
+    def delta(self, val: float) -> None:
         self._delta = radians(val)
 
     @delta.deleter
-    def delta(self):
-        self._delta = None
+    def delta(self) -> None:
+        self._delta = float("nan")
 
     @property
-    def nu(self) -> Union[float, None]:
+    def nu(self) -> float:
         """Value of of nu angle."""
         return degrees(self._nu)
 
     @nu.setter
-    def nu(self, val):
+    def nu(self, val: float) -> None:
         self._nu = radians(val)
 
     @nu.deleter
-    def nu(self):
-        self._nu = None
+    def nu(self) -> None:
+        self._nu = float("nan")
 
     @property
-    def eta(self) -> Union[float, None]:
+    def eta(self) -> float:
         """Value of of eta angle."""
         return degrees(self._eta)
 
     @eta.setter
-    def eta(self, val):
+    def eta(self, val: float) -> None:
         self._eta = radians(val)
 
     @eta.deleter
-    def eta(self):
-        self._eta = None
+    def eta(self) -> None:
+        self._eta = float("nan")
 
     @property
-    def chi(self) -> Union[float, None]:
+    def chi(self) -> float:
         """Value of of chi angle."""
         return degrees(self._chi)
 
     @chi.setter
-    def chi(self, val):
+    def chi(self, val: float) -> None:
         self._chi = radians(val)
 
     @chi.deleter
-    def chi(self):
-        self._chi = None
+    def chi(self) -> None:
+        self._chi = float("nan")
 
     @property
-    def phi(self) -> Union[float, None]:
+    def phi(self) -> float:
         """Value of of phi angle."""
         return degrees(self._phi)
 
     @phi.setter
-    def phi(self, val):
+    def phi(self, val: float) -> None:
         self._phi = radians(val)
 
     @phi.deleter
-    def phi(self):
-        self._phi = None
+    def phi(self) -> None:
+        self._phi = float("nan")
 
     @property
     def asdict(self) -> Dict[str, float]:

--- a/src/diffcalc/ub/calc.py
+++ b/src/diffcalc/ub/calc.py
@@ -10,7 +10,6 @@ import uuid
 from copy import deepcopy
 from itertools import product
 from math import acos, asin, cos, degrees, pi, radians, sin
-from pickle import UnpicklingError
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -204,7 +203,7 @@ class UBCalculation:
         with open(filename, "rb") as fp:
             try:
                 obj = pickle.load(fp)
-            except UnpicklingError as e:
+            except pickle.UnpicklingError as e:
                 raise DiffcalcException(e)
             if isinstance(obj, UBCalculation):
                 return obj
@@ -904,7 +903,6 @@ class UBCalculation:
         # ...and nornmalise and check that the reflections used are appropriate
 
         def __normalise(m):
-            SMALL = 1e-4  # Taken from Vlieg's code
             d = norm(m)
             if d < SMALL:
                 raise DiffcalcException(

--- a/src/diffcalc/ub/crystal.py
+++ b/src/diffcalc/ub/crystal.py
@@ -375,7 +375,7 @@ class Crystal:
         Returns
         -------
         float
-            The angle between the crystal lattice planes.
+            The angle between the crystal lattice planes in degrees.
         """
         hkl1_transpose = np.array([hkl1]).T
         hkl2_transpose = np.array([hkl2]).T

--- a/src/diffcalc/ub/fitting.py
+++ b/src/diffcalc/ub/fitting.py
@@ -3,7 +3,7 @@
 A module implementing fitting routines for refining crystal lattice parameters
 and U matrix using reflection data.
 """
-from math import atan2, cos, pi, sin, sqrt
+from math import atan2, cos, pi, radians, sin, sqrt
 from typing import List, Sequence, Tuple
 
 import numpy as np
@@ -61,7 +61,7 @@ def _func_orient(
         q_vals = inv(PHI) @ inv(CHI) @ inv(ETA) @ inv(MU) @ q_del
 
         q_hkl = tmp_ub @ hkl_vals
-        res += angle_between_vectors(q_hkl, q_vals)
+        res += radians(angle_between_vectors(q_hkl, q_vals))
     return res
 
 

--- a/src/diffcalc/util.py
+++ b/src/diffcalc/util.py
@@ -1,5 +1,5 @@
 """Collection of auxiliary mathematical methods."""
-from math import acos, cos, isclose, sin
+from math import acos, cos, degrees, isclose, radians, sin
 from typing import Any, Sequence, Tuple
 
 import numpy as np
@@ -147,13 +147,13 @@ def angle_between_vectors(x: np.ndarray, y: np.ndarray) -> float:
     Returns
     -------
     float
-        Angle between the vectors.
+        Angle between the vectors in degrees.
     """
     try:
         costheta = dot3(x * (1 / norm(x)), y * (1 / norm(y)))
     except ZeroDivisionError:
         return float("nan")
-    return acos(bound(costheta))
+    return degrees(acos(bound(costheta)))
 
 
 ## Math
@@ -191,15 +191,15 @@ def bound(x: float) -> float:
     return x
 
 
-def radians_equivalent(first: float, second: float, tolerance: float = SMALL) -> bool:
-    """Check for angle equivalence.
+def angles_equivalent(first: float, second: float, tolerance: float = SMALL) -> bool:
+    """Check for angle equivalence in degrees.
 
     Parameters
     ----------
     first: float
-        First angle value.
+        First angle value in degrees.
     second:float
-        Second angle value.
+        Second angle value in degrees.
     tolerance: float, default = SMALL
         Absolute tolerance for the angle difference.
 
@@ -209,8 +209,8 @@ def radians_equivalent(first: float, second: float, tolerance: float = SMALL) ->
         True is angles are equivalent.
 
     """
-    diff = sin((first - second) / 2.0)
-    return is_small(diff, tolerance)
+    diff = sin(radians(first - second) / 2.0)
+    return is_small(diff, radians(tolerance))
 
 
 def isnum(o: Any) -> bool:

--- a/tests/diffcalc/hkl/test_calc.py
+++ b/tests/diffcalc/hkl/test_calc.py
@@ -1,6 +1,6 @@
 import itertools
 from dataclasses import dataclass
-from math import isnan, pi, radians, sqrt
+from math import isnan, radians, sqrt
 from typing import Dict, List, Optional, Tuple, Union
 from unittest.mock import Mock
 
@@ -89,16 +89,15 @@ def convert_position_to_hkl_and_hkl_to_position(
     case: Case,
     places: int = 5,
     expected_virtual: Dict[str, float] = {},
-    asdegrees: bool = True,
 ) -> None:
 
-    position: Position = Position(*case.position, indegrees=asdegrees)
+    position: Position = Position(*case.position)
     hkl = hklcalc.get_hkl(position, case.wavelength)
 
     assert np.all(np.round(hkl, places) == np.round(case.hkl, places))
 
     pos_virtual_angles_pairs_in_degrees = hklcalc.get_position(
-        case.hkl[0], case.hkl[1], case.hkl[2], case.wavelength, asdegrees=asdegrees
+        case.hkl[0], case.hkl[1], case.hkl[2], case.wavelength
     )
 
     pos = [result[0] for result in pos_virtual_angles_pairs_in_degrees]
@@ -160,12 +159,12 @@ def test_serialisation(cubic: HklCalculation):
     assert hklcalc.asdict == hkl_json
 
 
-def test_get_position_with_radians(cubic: HklCalculation):
-    cubic.constraints = Constraints({"delta": 60, "a_eq_b": True, "mu": 0})
+def test_get_position(cubic: HklCalculation):
+    cubic.constraints = Constraints({"delta": 60.0, "a_eq_b": True, "mu": 0})
 
-    case = Case("100", (1, 0, 0), (0, pi / 3, 0, pi / 6, 0, 0))
+    case = Case("100", (1, 0, 0), (0, 60.0, 0, 30.0, 0, 0))
 
-    convert_position_to_hkl_and_hkl_to_position(cubic, case, asdegrees=False)
+    convert_position_to_hkl_and_hkl_to_position(cubic, case)
 
 
 @pytest.mark.parametrize(

--- a/tests/diffcalc/hkl/test_constraints.py
+++ b/tests/diffcalc/hkl/test_constraints.py
@@ -1,5 +1,5 @@
 from math import pi
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pytest
@@ -108,6 +108,11 @@ def test_all_init(con_dict, con_tuple, con_set, con_list):
         # eq_(cm.astuple, con_tuple)
 
 
+def test_wrong_parameter_to_init_raises_exception():
+    with pytest.raises(DiffcalcException):
+        Constraints(12)
+
+
 def test_constraints_stored_as_radians():
     deg_cons = Constraints({"alpha": 90, "mu": 30, "nu": 45})
 
@@ -139,6 +144,15 @@ def test_str_constraint(cm):
     )
 
 
+def test_str_constraint_for_non_implemented_combination():
+    cons = Constraints({"bisect": True, "omega": 30, "bin_eq_bout": True})
+
+    assert (
+        str(cons).split("\n")[-1]
+        == "    Sorry, this constraint combination is not implemented."
+    )
+
+
 def test_build_display_table(cm):
     cm.qaz = 1.234
     cm.alpha = 1.0
@@ -166,6 +180,43 @@ def test_setting_one_constraint_as_none(cm: Constraints):
     cm.mu = None
 
     assert cm.asdict == {"delta": 1.0}
+
+
+def test_setting_invalid_constraint_name(cm: Constraints):
+    with pytest.raises(DiffcalcException):
+        cm.asdict = {"non_existent": 10}
+
+    with pytest.raises(DiffcalcException):
+        cm.astuple = ("non_existent", 10.0)
+
+
+def test_all(cm: Constraints):
+    all_constraints: Dict[str, Optional[float]] = {
+        "delta": None,
+        "nu": None,
+        "qaz": None,
+        "naz": None,
+        "a_eq_b": None,
+        "alpha": None,
+        "beta": None,
+        "psi": None,
+        "bin_eq_bout": None,
+        "betain": None,
+        "betaout": None,
+        "mu": None,
+        "eta": None,
+        "chi": None,
+        "phi": None,
+        "bisect": None,
+        "omega": None,
+    }
+
+    assert cm.all == all_constraints
+
+    cm.alpha = 10
+    all_constraints["alpha"] = 10
+
+    assert cm.all == all_constraints
 
 
 def test_clear_constraints(cm):

--- a/tests/diffcalc/hkl/test_constraints.py
+++ b/tests/diffcalc/hkl/test_constraints.py
@@ -116,21 +116,6 @@ def test_constraints_stored_as_radians():
     assert deg_cons._nu.value == pi / 4
 
 
-def test_conversion_between_degrees_and_radians():
-    deg_cons = Constraints({"alpha": 90, "mu": 30, "nu": 45})
-    rad_cons = Constraints({"alpha": pi / 2, "mu": pi / 6, "nu": pi / 4})
-
-    cons_asradians = Constraints.asradians(deg_cons)
-
-    assert np.all(
-        [
-            pytest.approx(cons_asradians.asdict[key]) == rad_cons.asdict[key]
-            for key in ["alpha", "mu", "nu"]
-        ]
-    )
-    # NOTE: the conversion back does not work. i.e. Constraints.asdegrees is wrong.
-
-
 def test_str_constraint(cm):
     print(str(cm))
     eq_(
@@ -392,16 +377,6 @@ def test_setting_already_active_constraint():
     cons.mu = 90
 
     assert cons.mu == 90
-
-
-def test_radian_implementation_equivalent_to_degrees():
-    con_rad = Constraints({"mu": pi, "delta": pi / 2, "eta": pi / 6}, indegrees=False)
-    con_deg = Constraints({"mu": 180, "delta": 90, "eta": 30})
-
-    new_con_deg = Constraints.asdegrees(con_rad)
-    assert np.all(
-        [True for k, v in new_con_deg.asdict.items() if (v - con_deg.asdict[k]) == 0]
-    )
 
 
 def test_serialisation(cm):

--- a/tests/diffcalc/hkl/test_constraints.py
+++ b/tests/diffcalc/hkl/test_constraints.py
@@ -187,7 +187,7 @@ def test_setting_invalid_constraint_name(cm: Constraints):
         cm.asdict = {"non_existent": 10}
 
     with pytest.raises(DiffcalcException):
-        cm.astuple = ("non_existent", 10.0)
+        cm.astuple = (("non_existent", 10.0),)
 
 
 def test_all(cm: Constraints):

--- a/tests/diffcalc/hkl/test_geometry.py
+++ b/tests/diffcalc/hkl/test_geometry.py
@@ -1,4 +1,3 @@
-from math import degrees, pi
 from typing import Tuple
 
 import numpy as np
@@ -10,15 +9,6 @@ from numpy import array
 x = array([[1], [0], [0]])
 y = array([[0], [1], [0]])
 z = array([[0], [0], [1]])
-
-
-def test_comparison_between_radian_and_degree_positions():
-    pos_in_degrees = Position(90, 90, 90, 45, 30, 180)
-    pos_in_radians = Position(
-        pi / 2, pi / 2, pi / 2, pi / 4, pi / 6, pi, indegrees=False
-    )
-
-    assert pos_in_degrees == pos_in_radians
 
 
 def test_comparison_between_positions():
@@ -42,21 +32,6 @@ def test_position_string():
     )
 
 
-def test_position_str_converts_radians_to_degrees():
-    mu, delta, nu, eta, chi, phi = pi / 4, pi / 4, pi / 6, pi / 2, pi / 2, pi / 2
-    pos = Position(mu, delta, nu, eta, chi, phi, indegrees=False)
-
-    assert str(pos) == (
-        "Position("
-        + f"mu: {degrees(mu):.4f}, "
-        + f"delta: {degrees(delta):.4f}, "
-        + f"nu: {degrees(nu):.4f}, "
-        + f"eta: {degrees(eta):.4f}, "
-        + f"chi: {degrees(chi):.4f}, "
-        + f"phi: {degrees(phi):.4f})"
-    )
-
-
 def test_position_gets_and_sets_degrees_correctly():
     pos_deg = Position()
     angles = {"mu": 90, "delta": 90, "nu": 45, "eta": 30, "chi": 180, "phi": 60}
@@ -67,32 +42,13 @@ def test_position_gets_and_sets_degrees_correctly():
         assert np.round(retrieved_value, 8) == np.round(value, 8)
 
 
-def test_position_gets_and_sets_radians_correctly():
-    pos_deg = Position(indegrees=False)
-    angles = {
-        "mu": pi,
-        "delta": pi,
-        "nu": pi / 2,
-        "eta": pi / 6,
-        "chi": pi,
-        "phi": pi / 3,
-    }
-
-    for angle, value in angles.items():
-        setattr(pos_deg, angle, value)
-        retrieved_value = getattr(pos_deg, angle)
-        assert np.round(retrieved_value, 8) == np.round(value, 8)
-
-
-@pytest.mark.parametrize(
-    ("position"), [(0, pi / 2, pi / 4, pi, pi, pi), (0, 90, 45, 180, 180, 180)]
-)
+@pytest.mark.parametrize(("position"), [(0, 90, 45, 180, 180, 180)])
 def test_get_rotation_matrices_returns_correct_matrices(
     position: Tuple[float, float, float, float, float, float]
 ):
     matrices = get_rotation_matrices(Position(*position))
 
-    assert np.all(matrices[0] == I)
-    assert np.all(np.abs(np.round(matrices[3])) == I)
-    assert np.all(np.abs(np.round(matrices[4])) == I)
-    assert np.all(np.abs(np.round(matrices[5])) == I)
+    assert np.allclose(matrices[0], I)
+    assert np.allclose(np.abs(matrices[3]), I)
+    assert np.allclose(np.abs(matrices[4]), I)
+    assert np.allclose(np.abs(matrices[5]), I)

--- a/tests/diffcalc/hkl/test_geometry.py
+++ b/tests/diffcalc/hkl/test_geometry.py
@@ -63,8 +63,11 @@ def test_delete_position_properties():
     del position.chi
     del position.phi
 
-    with pytest.raises(TypeError):
-        position.mu
+    assert np.isnan(position.mu)
+    assert np.isnan(position.delta)
+    assert np.isnan(position.nu)
+    assert np.isnan(position.eta)
+    assert np.isnan(position.chi)
+    assert np.isnan(position.phi)
 
-    with pytest.raises(TypeError):
-        position.asdict
+    assert all(np.isnan(v) for v in position.asdict.values())

--- a/tests/diffcalc/hkl/test_geometry.py
+++ b/tests/diffcalc/hkl/test_geometry.py
@@ -51,3 +51,20 @@ def test_get_rotation_matrices_returns_correct_matrices(
     assert np.allclose(np.abs(matrices[3]), I)
     assert np.allclose(np.abs(matrices[4]), I)
     assert np.allclose(np.abs(matrices[5]), I)
+
+
+def test_delete_position_properties():
+    position = Position(1, 2, 3, 4, 5, 6)
+
+    del position.mu
+    del position.delta
+    del position.nu
+    del position.eta
+    del position.chi
+    del position.phi
+
+    with pytest.raises(TypeError):
+        position.mu
+
+    with pytest.raises(TypeError):
+        position.asdict

--- a/tests/diffcalc/hkl/test_geometry.py
+++ b/tests/diffcalc/hkl/test_geometry.py
@@ -4,11 +4,10 @@ import numpy as np
 import pytest
 from diffcalc.hkl.geometry import Position, get_rotation_matrices
 from diffcalc.util import I
-from numpy import array
 
-x = array([[1], [0], [0]])
-y = array([[0], [1], [0]])
-z = array([[0], [0], [1]])
+x = np.array([[1], [0], [0]])
+y = np.array([[0], [1], [0]])
+z = np.array([[0], [0], [1]])
 
 
 def test_comparison_between_positions():

--- a/tests/diffcalc/test_utils.py
+++ b/tests/diffcalc/test_utils.py
@@ -1,17 +1,17 @@
 from diffcalc.util import DiffcalcException
 
-from tests.tools import degrees_equivalent
+from tests.tools import angles_equivalent
 
 
 class TestUtils:
     def testDegreesEqual(self):
         tol = 0.001
-        assert degrees_equivalent(1, 1, tol)
-        assert degrees_equivalent(1, -359, tol)
-        assert degrees_equivalent(359, -1, tol)
-        assert not degrees_equivalent(1.1, 1, tol)
-        assert not degrees_equivalent(1.1, -359, tol)
-        assert not degrees_equivalent(359.1, -1, tol)
+        assert angles_equivalent(1, 1, tol)
+        assert angles_equivalent(1, -359, tol)
+        assert angles_equivalent(359, -1, tol)
+        assert not angles_equivalent(1.1, 1, tol)
+        assert not angles_equivalent(1.1, -359, tol)
+        assert not angles_equivalent(359.1, -1, tol)
 
 
 def test_exception():

--- a/tests/diffcalc/ub/test_calc.py
+++ b/tests/diffcalc/ub/test_calc.py
@@ -10,7 +10,6 @@ import pytest
 from diffcalc.hkl.geometry import Position
 from diffcalc.ub.calc import ReferenceVector, UBCalculation
 from diffcalc.util import DiffcalcException
-from numpy import array
 
 from tests.diffcalc import scenarios
 
@@ -391,9 +390,9 @@ def test_get_ttheta_from_hkl(ubcalc: UBCalculation):
             [np.pi / 6, np.pi / 12, np.pi / 4],
             [False, True, True],
             [
-                array([[-0.5], [0], [0.8660254]]),
-                array([[-0.7071068], [0], [0.7071068]]),
-                array([[0.0], [0.0], [1.0]]),
+                np.array([[-0.5], [0], [0.8660254]]),
+                np.array([[-0.7071068], [0], [0.7071068]]),
+                np.array([[0.0], [0.0], [1.0]]),
             ],
         ),
     ],

--- a/tests/diffcalc/ub/test_calc.py
+++ b/tests/diffcalc/ub/test_calc.py
@@ -232,7 +232,7 @@ def ubcalc() -> UBCalculation:
 
 def test_set_lattice_with_wrong_types_raises_exceptions(ubcalc: UBCalculation):
     with pytest.raises(TypeError):
-        ubcalc.set_lattice(12, "Tetragonal", 1, 2, 3, 4, 5, 6)
+        ubcalc.set_lattice(12, "Tetragonal", 1, 2, 3, 4, 5, 6)  # type: ignore
 
     with pytest.raises(TypeError):
         ubcalc.set_lattice("", 12, 1, 2, 3, 4, 5, 6)

--- a/tests/diffcalc/ub/test_crystal.py
+++ b/tests/diffcalc/ub/test_crystal.py
@@ -1,4 +1,4 @@
-from math import atan, sqrt
+from math import atan, degrees, sqrt
 
 import numpy as np
 import pytest
@@ -45,10 +45,10 @@ def test_get_lattice_and_get_lattice_params(xtal_system, unit_cell, full_unit_ce
 @pytest.mark.parametrize(
     ("hkl1", "hkl2", "angle"),
     [
-        ([0, 0, 1], [0, 0, 2], 0),
-        ([0, 1, 0], [0, 0, 2], np.pi / 2),
-        ([1, 0, 1], [0, 0, 2], np.pi / 4),
-        ([1, 1, 1], [0, 0, 2], atan(sqrt(2.0))),
+        ([0, 0, 1], [0, 0, 2], 0.0),
+        ([0, 1, 0], [0, 0, 2], 90.0),
+        ([1, 0, 1], [0, 0, 2], 45.0),
+        ([1, 1, 1], [0, 0, 2], degrees(atan(sqrt(2.0)))),
     ],
 )
 def test_get_hkl_plane_angle(hkl1, hkl2, angle):

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -16,9 +16,7 @@
 # along with Diffcalc.  If not, see <http://www.gnu.org/licenses/>.
 ###
 
-from math import radians
-
-from diffcalc.util import SMALL, radians_equivalent
+from diffcalc.util import angles_equivalent
 from pytest import approx
 
 
@@ -46,7 +44,7 @@ def assert_array_almost_equal(first, second, places=7, msg=None, note=None):
         #    format_note(note),
         # )
         # assert_almost_equal(f, s, places, msg or default_msg)
-        assert degrees_equivalent(f, s, pow(10, -places))
+        assert angles_equivalent(f, s, pow(10, -places))
 
 
 def assert_array_almost_equal_in_list(expected, vals, places=7, msg=None):
@@ -161,7 +159,3 @@ def assert_iterable_almost_equal(first, second, places=7, msg=None, note=None):
 
 
 mneq_ = matrixeq_ = assert_matrix_almost_equal
-
-
-def degrees_equivalent(first, second, tolerance=SMALL):
-    return radians_equivalent(radians(first), radians(second), radians(tolerance))


### PR DESCRIPTION
Following a common convention of working in degrees for diffractometer angles and unit cell parameters,  drop `indegrees`, `asdegrees` and `asradians` attributes and method parameters in favour of returning all angle values in degrees by API methods.