### PR TITLE
set_miscut and get_miscut: change to degree usage only

### DIFF
--- a/src/diffcalc/ub/calc.py
+++ b/src/diffcalc/ub/calc.py
@@ -1272,7 +1272,7 @@ class UBCalculation:
         Returns
         -------
         Tuple[float, Tuple[float, float, float]]
-            The miscut angle and the corresponding miscut rotation axis.
+            The miscut angle in degrees and the corresponding miscut rotation axis.
         """
         q_vec = get_q_phi(pos)
         hkl_nphi = self.UB @ np.array([hkl]).T

--- a/src/diffcalc/ub/calc.py
+++ b/src/diffcalc/ub/calc.py
@@ -1111,7 +1111,7 @@ class UBCalculation:
             self.set_lattice(*lat)
         mc_angle, mc_axis = self.get_miscut_from_hkl(hkl, position)
         if mc_angle and refine_umatrix:
-            self.set_miscut(mc_axis, radians(mc_angle), True)
+            self.set_miscut(mc_axis, mc_angle, True)
 
     def fit_ub(
         self,
@@ -1302,15 +1302,15 @@ class UBCalculation:
         xyz: Tuple[float, float, float]
             Rotation axis corresponding to the crystal miscut.
         angle: float
-            The miscut angle.
+            The miscut angle, in degrees.
         add_miscut: Optional[bool], default = False
             If False, set crystal miscut to the provided parameters.
             If True, apply provided miscut parameters to the existing settings.
         """
         if xyz is None:
-            rot_matrix = xyz_rotation((0, 1, 0), angle)
+            rot_matrix = xyz_rotation((0, 1, 0), radians(angle))
         else:
-            rot_matrix = xyz_rotation(xyz, angle)
+            rot_matrix = xyz_rotation(xyz, radians(angle))
         if self.U is not None and add_miscut:
             new_U = rot_matrix @ self.U
         else:

--- a/tests/diffcalc/ub/test_calc.py
+++ b/tests/diffcalc/ub/test_calc.py
@@ -64,7 +64,7 @@ class TestStrings:
         self.ubcalc.add_orientation(
             (0, 1, 0), (0, 1, 0), Position(1, 0, 0, 0, 2, 0), "orient1"
         )
-        self.ubcalc.set_miscut(None, radians(2.0))
+        self.ubcalc.set_miscut(None, 2.0)
 
         assert str(self.ubcalc) == self.retrieve_expected_string("full_info")
 
@@ -81,7 +81,7 @@ class TestPersistenceMethods:
     ubcalc.set_lattice("xtal", "Cubic", 1)
     ubcalc.add_reflection((0, 0, 1), Position(0, 60, 0, 30, 0, 0), 12.4, "ref1")
     ubcalc.add_orientation((0, 1, 0), (0, 1, 0), Position(1, 0, 0, 0, 2, 0), "orient1")
-    ubcalc.set_miscut(None, radians(2.0))
+    ubcalc.set_miscut(None, 2.0)
 
     def test_pickling(self):
         self.ubcalc.pickle("test_file")
@@ -439,7 +439,7 @@ def test_get_ttheta_from_hkl(ubcalc: UBCalculation):
     [
         (
             [(0, 1, 0), (0, 1, 0), (0, -1, 0)],
-            [np.pi / 6, np.pi / 12, np.pi / 4],
+            [30, 15, 45],
             [False, True, True],
             [
                 np.array([[-0.5], [0], [0.8660254]]),
@@ -479,7 +479,7 @@ def test_get_miscut_from_hkl(
     pos: Position,
 ):
     ubcalc.set_lattice("xtal", 1, 1, 1, 90, 90, 90)
-    ubcalc.set_miscut(axis, radians(angle))
+    ubcalc.set_miscut(axis, angle)
     ubcalc.set_miscut(None, 0)
 
     miscut, miscut_axis = ubcalc.get_miscut_from_hkl(hkl, pos)
@@ -496,7 +496,7 @@ def test_get_miscut_from_hkl(
 )
 def test_get_miscut(ubcalc, axis, angle):
     ubcalc.set_lattice("xtal", 1, 1, 1, 90, 90, 90)
-    ubcalc.set_miscut(axis, radians(angle))
+    ubcalc.set_miscut(axis, angle)
 
     test_angle, test_axis = ubcalc.get_miscut()
 


### PR DESCRIPTION
changed inputs/outputs of set_miscut and get_miscut to deal with radians rather than degrees

Currently, the angles in both of these methods manipulate radians, in contrast to the other methods in this library.